### PR TITLE
Reuse regression helpers in binary sharp null test

### DIFF
--- a/R/compute_bounds_ats_new.R
+++ b/R/compute_bounds_ats_new.R
@@ -87,7 +87,7 @@ trimmed_expectation_from_cdf <- function(ecdf_table,
 #' @param m Name of the mediator variable
 #' @param y Name of the outcome variable
 #' @param at_group The AT group of interest. Default is 1, so we compute means for units with M(1)=M(0)=1.
-#' @param max_defiers_share Bound on the proportion of defiers in the population. Default is 0 which indicates that the monotonicity constraint is imposed.
+#' @param max_defier_share Bound on the proportion of defiers in the population. Default is 0 which indicates that the monotonicity constraint is imposed.
 #' @param num_gridpoints (Optional.) The number of gridpoints used in evaluating the integral. Higher is more accurate but more computationally costly
 #' @importFrom "stats" "quantile"
 #' @export
@@ -358,7 +358,7 @@ compute_bounds_ats_new <- function(df,
                                     defiers_constraints_matrix)
   
   #Combine the constants associated with the matrices
-  rhs_vec <- c(p_m_1, p_m_0, max_p_diffs, max_defiers_share)
+  rhs_vec <- c(p_m_1, p_m_0, max_p_diffs, max_defier_share)
   
   #Specify the direction of the equalities/inequalities
   dir <- c(rep("==", 2*NROW(m1_marginals_constraints_matrix)),

--- a/R/compute_bounds_ats_new.R
+++ b/R/compute_bounds_ats_new.R
@@ -135,6 +135,28 @@ compute_bounds_ats_new <- function(df,
                                m = m,
                                y = y)
 
+  ensure_treatment_term <- function(fml, treat_var) {
+    fml_chr <- paste(deparse(fml), collapse = " ")
+    treat_pattern <- paste0("\\b", treat_var, "\\b")
+    if (!grepl(treat_pattern, fml_chr)) {
+      warning("The treatment variable '", treat_var,
+              "' was not found in the provided reg_formula; ",
+              "I have added it as a regressor. Please edit reg_formula if that was not your intention.")
+      rhs_chr <- sub("^~", "", fml_chr)
+      if (nzchar(rhs_chr)) {
+        fml_chr <- paste("~", treat_var, "+", rhs_chr)
+      } else {
+        fml_chr <- paste("~", treat_var)
+      }
+      fml <- as.formula(fml_chr)
+    }
+    fml
+  }
+
+  if (!is.null(reg_formula)) {
+    reg_formula <- ensure_treatment_term(reg_formula, d)
+  }
+
   yvec <- df[[y]]
   dvec <- df[[d]]
   mvec <- df[[m]]
@@ -228,20 +250,23 @@ compute_bounds_ats_new <- function(df,
   
   defier_types <- 1-monotonic_types
   
-  #Compute the marginal distribution of M among D=1
-  p_m_1_fn <- function(mvalue){
-    mdf1 <- mdf[dvec == 1,, drop = FALSE]
-    M_equals_mvalue <- base::sapply(1:NROW(mdf1), function(i) .row_equals(mdf1[i,], mvalue))
-    mean(M_equals_mvalue)
+  if (is.null(reg_formula)) {
+    p_m_1_fn <- function(mvalue){
+      mdf1 <- mdf[dvec == 1,, drop = FALSE]
+      M_equals_mvalue <- base::sapply(1:NROW(mdf1), function(i) .row_equals(mdf1[i,], mvalue))
+      mean(M_equals_mvalue)
+    }
+    p_m_0_fn <- function(mvalue){
+      mdf0 <- mdf[dvec == 0, , drop = FALSE]
+      M_equals_mvalue <- base::sapply(1:NROW(mdf0), function(i) .row_equals(mdf0[i,], mvalue))
+      mean(M_equals_mvalue)
+    }
+
+    p_m_1 <- base::apply(mvalues, 1, p_m_1_fn)
+    p_m_0 <- base::apply(mvalues, 1, p_m_0_fn)
+  } else {
+    p_m_1 <- p_m_0 <- rep(NA_real_, nrow(mvalues))
   }
-  p_m_0_fn <- function(mvalue){
-    mdf0 <- mdf[dvec == 0, , drop = FALSE]
-    M_equals_mvalue <- base::sapply(1:NROW(mdf0), function(i) .row_equals(mdf0[i,], mvalue))
-    mean(M_equals_mvalue)
-  }
-  
-  p_m_1 <- base::apply(mvalues, 1, p_m_1_fn)
-  p_m_0 <- base::apply(mvalues, 1, p_m_0_fn)
   
 
   
@@ -252,6 +277,8 @@ compute_bounds_ats_new <- function(df,
   is_discrete_Y <- !( n / length(unique(df[[y]])) <= 30 )
   
   
+  regression_probs <- NULL
+
   if (is.null(reg_formula)) {
     max_p_diffs_list <- compute_max_p_difference(
       dvec = dvec,
@@ -276,8 +303,31 @@ compute_bounds_ats_new <- function(df,
       y    = y,
       reg_formula = reg_formula
     )
+    regression_probs <- max_p_diffs_list
   }
   max_p_diffs <- max_p_diffs_list$max_p_diffs
+
+  if (!is.null(regression_probs)) {
+    my_values_reg <- regression_probs$my_values
+    p_ym_0_vec <- regression_probs$p_ym_0_vec
+    p_ym_1_vec <- regression_probs$p_ym_1_vec
+
+    p_m_0 <- vapply(
+      seq_len(nrow(mvalues)),
+      function(idx) {
+        sum(p_ym_0_vec[my_values_reg$m == idx])
+      },
+      numeric(1)
+    )
+
+    p_m_1 <- vapply(
+      seq_len(nrow(mvalues)),
+      function(idx) {
+        sum(p_ym_1_vec[my_values_reg$m == idx])
+      },
+      numeric(1)
+    )
+  }
   
   
   # build the same constraint matrices as in lb_frac_affected
@@ -380,9 +430,23 @@ compute_bounds_ats_new <- function(df,
   theta_kk_min <- as.numeric(theta_lp$optimum)
   
   
+  at_group_index <- which(purrr::map_lgl(
+    .x = 1:NROW(mvalues),
+    .f = ~.row_equals(mvalues[.x, , drop = FALSE], at_group)
+  ))
+
   # Replace shares: θ_{kk}^{min} / P(M=k | D=d)
-  p_mk_d1 <- mean(mvec[dvec == 1] == at_group)
-  p_mk_d0 <- mean(mvec[dvec == 0] == at_group)
+  if (is.null(reg_formula)) {
+    p_mk_d1 <- mean(mvec[dvec == 1] == at_group)
+    p_mk_d0 <- mean(mvec[dvec == 0] == at_group)
+  } else {
+    if (!length(at_group_index)) {
+      warning("The requested at_group does not appear in the mediator support; returning NA bounds.")
+      return(data.frame(lb = NA_real_, ub = NA_real_))
+    }
+    p_mk_d1 <- p_m_1[at_group_index]
+    p_mk_d0 <- p_m_0[at_group_index]
+  }
   if (p_mk_d1 <= 0 || p_mk_d0 <= 0) {
     warning("P(M=at_group | D=d) is zero for some d; returning NA bounds.")
     return(data.frame(lb = NA_real_, ub = NA_real_))
@@ -407,71 +471,34 @@ compute_bounds_ats_new <- function(df,
   ecdf_y_mkd0 <- ecdf_y_mkd0_fn(yvalues) #this is a vector of CDFs evaluated at yvalues
   } else{
     # Regression-inferred CDFs (discrete Y only)
-    yuniq <- sort(unique(yvec))
     if (!is_discrete_Y) {
       stop("reg_formula currently supported for discrete Y; Y variable might be continuous.")
     }
-    
-    # Match mediator pattern: M == at_group
-    m_match <- apply(mdf, 1, function(row) row_equals(row, at_group))
-    
-    # Parse OLS/IV spec
-    iv_spec <- extract_iv(reg_formula, d)
-    
-    # Allocate joint probabilities for each y and each d
-    partial_pmf_d1 <- numeric(length(yvalues))
-    partial_pmf_d0 <- numeric(length(yvalues))
-    
-    for (j in seq_along(yvalues)) {
-      y_val <- yvalues[j]
-      df$lhs <- as.integer(yvec == y_val & m_match)  # indicator {Y=y_val, M=at_group}
-      
-      # Build fixest formula
-      if (iv_spec$is_iv) {
-        ctrl  <- paste(iv_spec$controls, collapse = " + ")
-        instr <- paste(iv_spec$instr,     collapse = " + ")
-        fml   <- as.formula(sprintf("lhs ~ %s | %s ~ %s",
-                                    ctrl,
-                                    paste(iv_spec$treat, collapse = "+"),
-                                    instr))
-      } else {
-        rhs <- paste(c(iv_spec$treat, iv_spec$controls), collapse = " + ")
-        fml <- as.formula(paste("lhs ~", rhs))
-      }
-      
-      # Vars, drop NA
-      req <- c("lhs", d, iv_spec$controls, if (iv_spec$is_iv) iv_spec$instr else NULL)
-      req <- unique(req[nzchar(req)])
-      df_fit <- tidyr::drop_na(df[, req, drop = FALSE])
-      if (nrow(df_fit) == 0) { partial_pmf_d1[j] <- 0; partial_pmf_d0[j] <- 0; next }
-      
-      # Fit model
-      mod <- fixest::feols(fml, data = df_fit)
-      
-      # Counterfactual sets for D=1 and D=0
-      new1 <- df_fit
-      new1[[d]] <- 1
-      new0 <- df_fit
-      new0[[d]] <- 0
-      
-      pred1 <- as.numeric(predict(mod, newdata = new1))
-      pred0 <- as.numeric(predict(mod, newdata = new0))
-      
-      # Average predicted joint probs: P(Y=y, M=k | D=d)
-      partial_pmf_d1[j] <- mean(pred1, na.rm = TRUE)
-      partial_pmf_d0[j] <- mean(pred0, na.rm = TRUE)
+
+    if (!length(at_group_index)) {
+      warning("The requested at_group does not appear in the mediator support; returning NA bounds.")
+      return(data.frame(lb = NA_real_, ub = NA_real_))
     }
-    
-    # Convert to conditional PMFs of Y | M=k, D=d
-    # Nonnegative joint predictions (from your regression loop):
-    joint1 <- pmax(0, as.numeric(partial_pmf_d1))  # ≈ P(Y=y, M=at_group | D=1)
-    joint0 <- pmax(0, as.numeric(partial_pmf_d0))  # ≈ P(Y=y, M=at_group | D=0)
-    
-    # Build a VALID conditional PMF with safe empirical fallback
+
+    m_match <- apply(mdf, 1, function(row) .row_equals(row, at_group))
+
+    extract_joint <- function(prob_vec) {
+      vapply(
+        yvalues,
+        function(y_val) {
+          idx <- which(my_values_reg$y == y_val & my_values_reg$m == at_group_index)
+          if (length(idx) == 0) 0 else prob_vec[idx]
+        },
+        numeric(1)
+      )
+    }
+
+    joint1 <- pmax(0, extract_joint(p_ym_1_vec))
+    joint0 <- pmax(0, extract_joint(p_ym_0_vec))
+
     build_conditional_pmf <- function(joint, y_cell) {
       s <- sum(joint)
       if (!is.finite(s) || s <= .Machine$double.eps) {
-        # fallback: empirical conditional PMF of Y | M=at_group, D=d
         if (length(y_cell) == 0L) return(rep(0, length(yvalues)))
         tab <- table(factor(y_cell, levels = yvalues))
         return(as.numeric(tab) / sum(tab))
@@ -482,27 +509,21 @@ compute_bounds_ats_new <- function(df,
       if (s2 > 0) pmf <- pmf / s2
       pmf
     }
-    
-    pmf1 <- build_conditional_pmf(joint1, y_cell = yvec[mvec == at_group & dvec == 1])
-    pmf0 <- build_conditional_pmf(joint0, y_cell = yvec[mvec == at_group & dvec == 0])
-    
-    # Raw CDF vectors
-    ecdf_y_mkd1 <- cumsum(pmf1)
-    ecdf_y_mkd0 <- cumsum(pmf0)
-    
-    # --- Validator that takes ONLY the CDF vector and returns a fixed CDF vector ---
-    .validate_cdf <- function(cdfv) {
+
+    pmf1 <- build_conditional_pmf(joint1, y_cell = yvec[m_match & dvec == 1])
+    pmf0 <- build_conditional_pmf(joint0, y_cell = yvec[m_match & dvec == 0])
+
+    validate_cdf <- function(cdfv) {
       if (!length(cdfv)) return(cdfv)
       cdfv[!is.finite(cdfv)] <- 0
-      cdfv <- pmin(1, pmax(0, cdfv))  # clamp to [0,1]
-      cdfv <- cummax(cdfv)            # enforce nondecreasing
-      cdfv[length(cdfv)] <- 1         # FORCE last point to 1
+      cdfv <- pmin(1, pmax(0, cdfv))
+      cdfv <- cummax(cdfv)
+      cdfv[length(cdfv)] <- 1
       cdfv
     }
-    
-    # Validate the CDF vectors
-    ecdf_y_mkd1 <- .validate_cdf(ecdf_y_mkd1)
-    ecdf_y_mkd0 <- .validate_cdf(ecdf_y_mkd0)
+
+    ecdf_y_mkd1 <- validate_cdf(cumsum(pmf1))
+    ecdf_y_mkd0 <- validate_cdf(cumsum(pmf0))
     }
   
   

--- a/R/lb_frac_affected.R
+++ b/R/lb_frac_affected.R
@@ -527,10 +527,13 @@ compute_max_p_difference_reg <- function(dvec,
   mdf  <- mdf[keep_rows, , drop = FALSE]
   df   <- df[keep_rows, , drop = FALSE]
 
-  # create a univariate representation of the mediator patterns so we can reuse
-  # the regression helpers defined in test_sharp_null.R
+  # The regression helpers operate on a single integer-coded mediator. When the
+  # mediator is multivariate, we collapse each row to a string "key" and use it
+  # to map every observation onto the index of its unique mediator pattern.
   mvalues <- unique(mdf)
   row_key <- function(mat) {
+    # use "\r" as a separator because it is unlikely to appear in factor names
+    # or numeric representations, which prevents accidental key collisions
     apply(mat, 1, function(row) paste(row, collapse = "\r"))
   }
   m_keys <- row_key(mdf)

--- a/R/lb_frac_affected.R
+++ b/R/lb_frac_affected.R
@@ -87,7 +87,7 @@ lb_frac_affected <- function(df,
     wvec <- df[[w]]
   }
 
-  if(is.null(reg_formula) || identical(as.character(reg_formula), "~ treat") || continuous_Y){
+  if(is.null(reg_formula) || continuous_Y){
   max_p_diffs_list <- compute_max_p_difference(dvec = dvec,
                                                mdf = mdf,
                                                yvec = yvec,
@@ -132,7 +132,6 @@ lb_frac_affected <- function(df,
 
 
     if (!is.null(reg_formula) &&
-        !identical(as.character(reg_formula), "~ treat") &&
         !continuous_Y) {
       my_values <- max_p_diffs_list$my_values
       p_ym_1_vec <- max_p_diffs_list$p_ym_1_vec

--- a/R/partial_density_plot.R
+++ b/R/partial_density_plot.R
@@ -212,14 +212,14 @@ compute_partial_densities_and_shares <- function(df,
       pmf_y_ats_treated <- purrr::map_dbl(.x = 1:length(yvalues),
                                           .f = ~stats::weighted.mean(x = y_ats_treated == yvalues[.x],
                                                                      w = w_ats_treated))
-      
+
       pmf_y_ats_untreated <- purrr::map_dbl(.x = 1:length(yvalues),
                                             .f = ~stats::weighted.mean(x = y_ats_untreated == yvalues[.x],
                                                                        w = w_ats_untreated))
-      
+
       pmf_partial_11 <- (frac_ats + frac_compliers) * pmf_y_ats_treated
       pmf_partial_01 <- (frac_ats) * pmf_y_ats_untreated
-      
+
       resultsList <-
         list(frac_compliers = frac_compliers,
              frac_ats = frac_ats,
@@ -233,65 +233,74 @@ compute_partial_densities_and_shares <- function(df,
       if (continuous_Y){
         stop("reg_formula is only allowed when Y is discrete (set continuous_Y = FALSE or supply num_Ybins).")
       }else{
-     
-      # ---- ensure treatment on RHS ---------------------------------
-      reg_formula_chr <- paste(deparse(reg_formula), collapse = " ")
-      if (!grepl("\\btreat\\b", reg_formula_chr)) {
-        warning("The treatment variable '", d,
-                "' was not found in the provided reg_formula; ",
-                "I have added it as a regressor. Please edit reg_formula if that was not your intention.")
-        reg_formula_chr <- paste("~", d, "+", sub("^~", "", reg_formula_chr))
-        reg_formula     <- as.formula(reg_formula_chr)
-      }
-      
-      # ---- predicted P(M=1 | D=d)  ----------------------------------
-      p_m1 <- .predict_mean(lhs_vec = as.integer(mvec == 1),
-                            df      = df,
-                            d_var   = d,
-                            d_val   = 1,
-                            reg_formula = reg_formula,
-                            wvec    = wvec)
-      p_m0 <- .predict_mean(lhs_vec = as.integer(mvec == 1),
-                            df      = df,
-                            d_var   = d,
-                            d_val   = 0,
-                            reg_formula = reg_formula,
-                            wvec    = wvec)
-      
-      frac_compliers <- p_m1 - p_m0
-      frac_ats       <- p_m0
-      theta_ats      <- frac_ats / (frac_compliers + frac_ats)
-      
-      # ---- joint probabilities for each y ---------------------------
-      yvalues <- sort(unique(yvec))
-      
-      pmf_partial11 <- purrr::map_dbl(
-        yvalues,
-        ~.predict_mean(lhs_vec = as.integer((yvec == .x) & (mvec == 1)),
-                       df      = df,
-                       d_var   = d,
-                       d_val   = 1,
-                       reg_formula = reg_formula,
-                       wvec    = wvec)
-      )
-      
-      pmf_partial01 <- purrr::map_dbl(
-        yvalues,
-        ~.predict_mean(lhs_vec = as.integer((yvec == .x) & (mvec == 1)),
-                       df      = df,
-                       d_var   = d,
-                       d_val   = 0,
-                       reg_formula = reg_formula,
-                       wvec    = wvec)
-      )
-      
-      # Return (discrete-Y only)
-      resultsList <- list(frac_compliers = frac_compliers,
-           frac_ats       = frac_ats,
-           theta_ats      = theta_ats,
-           pmf_partial11  = pmf_partial11,
-           pmf_partial01  = pmf_partial01,
-           yvalues        = yvalues)
+
+        ensure_treatment_term <- function(fml, treat_var) {
+          fml_chr <- paste(deparse(fml), collapse = " ")
+          treat_pattern <- paste0("\\b", treat_var, "\\b")
+          if (!grepl(treat_pattern, fml_chr)) {
+            warning("The treatment variable '", treat_var,
+                    "' was not found in the provided reg_formula; ",
+                    "I have added it as a regressor. Please edit reg_formula if that was not your intention.")
+            rhs_chr <- sub("^~", "", fml_chr)
+            if (nzchar(rhs_chr)) {
+              fml_chr <- paste("~", treat_var, "+", rhs_chr)
+            } else {
+              fml_chr <- paste("~", treat_var)
+            }
+            fml <- as.formula(fml_chr)
+          }
+          fml
+        }
+
+        reg_formula <- ensure_treatment_term(reg_formula, d)
+
+        yvalues <- sort(unique(yvec))
+        mvalues <- unique(mvec)
+        my_values <- purrr::cross_df(list(m = mvalues, y = yvalues)) %>%
+          dplyr::arrange(m, y) %>%
+          dplyr::select(y, m)
+        my_values$m <- as.numeric(as.character(my_values$m))
+        m_one_value <- max(as.numeric(as.character(mvalues)))
+
+        p_ym_0_vec <- compute_regression_probs(df = df,
+                                               yvec = yvec,
+                                               mvec = mvec,
+                                               my_values = my_values,
+                                               d = d,
+                                               reg_formula = reg_formula,
+                                               transform_fun = control_transform)
+
+        p_ym_1_vec <- compute_regression_probs(df = df,
+                                               yvec = yvec,
+                                               mvec = mvec,
+                                               my_values = my_values,
+                                               d = d,
+                                               reg_formula = reg_formula,
+                                               transform_fun = treated_transform)
+
+        p_m_0 <- sum(p_ym_0_vec[my_values$m == m_one_value])
+        p_m_1 <- sum(p_ym_1_vec[my_values$m == m_one_value])
+
+        frac_compliers <- p_m_1 - p_m_0
+        frac_ats       <- p_m_0
+        theta_ats      <- frac_ats / (frac_compliers + frac_ats)
+
+        lookup_joint <- function(prob_vec) {
+          vapply(yvalues, function(y_val) {
+            idx <- which(my_values$y == y_val & my_values$m == m_one_value)
+            if (length(idx) == 0) 0 else prob_vec[idx]
+          }, numeric(1))
+        }
+
+        pmf_partial11 <- lookup_joint(p_ym_1_vec)
+        pmf_partial01 <- lookup_joint(p_ym_0_vec)
+
+        resultsList <- list(frac_compliers = frac_compliers,
+             frac_ats       = frac_ats,
+             theta_ats      = theta_ats,
+             pmf_partial11  = pmf_partial11,
+             pmf_partial01  = pmf_partial01,
+             yvalues        = yvalues)
     }
     }
     return(resultsList)

--- a/R/partial_density_plot.R
+++ b/R/partial_density_plot.R
@@ -234,26 +234,6 @@ compute_partial_densities_and_shares <- function(df,
         stop("reg_formula is only allowed when Y is discrete (set continuous_Y = FALSE or supply num_Ybins).")
       }else{
 
-        ensure_treatment_term <- function(fml, treat_var) {
-          fml_chr <- paste(deparse(fml), collapse = " ")
-          treat_pattern <- paste0("\\b", treat_var, "\\b")
-          if (!grepl(treat_pattern, fml_chr)) {
-            warning("The treatment variable '", treat_var,
-                    "' was not found in the provided reg_formula; ",
-                    "I have added it as a regressor. Please edit reg_formula if that was not your intention.")
-            rhs_chr <- sub("^~", "", fml_chr)
-            if (nzchar(rhs_chr)) {
-              fml_chr <- paste("~", treat_var, "+", rhs_chr)
-            } else {
-              fml_chr <- paste("~", treat_var)
-            }
-            fml <- as.formula(fml_chr)
-          }
-          fml
-        }
-
-        reg_formula <- ensure_treatment_term(reg_formula, d)
-
         yvalues <- sort(unique(yvec))
         mvalues <- unique(mvec)
         my_values <- purrr::cross_df(list(m = mvalues, y = yvalues)) %>%

--- a/R/test_sharp_null_binary_m.R
+++ b/R/test_sharp_null_binary_m.R
@@ -24,7 +24,6 @@
 #'  @param lambda (For FSST only) A string variable, either dd or ndd, standing for data-driven or non-data driven respectively.
 #'  @param analytic_variance (For CS or ARP only) A flag indicating whether to use analytic variance.
 #'  @param refinement (For CS only, optional) If TRUE, use the refined Cox & Shi test (rCC rather than CC). Default is FALSE.
-#'  @param print_both_var (For CS only, Optional) If TRUE, print sigma from both actual and bootstrapped data.
 #' @export
 
 test_sharp_null_binary_m <- function(df,
@@ -45,8 +44,7 @@ test_sharp_null_binary_m <- function(df,
                                      fix_n1 = T,
                                      lambda = "dd",    #fsst arg
                                      analytic_variance = FALSE,    # arp cs arg
-                                     refinement = FALSE,    #cs arg
-                                     print_both_var = FALSE    #cs arg
+                                     refinement = FALSE    #cs arg
                                      ){
   
   ## Remove missing
@@ -185,13 +183,6 @@ test_sharp_null_binary_m <- function(df,
                                      clustervec = clustervec,
                                      exploit_binary_m = TRUE)
       
-      if (method == "CS" & print_both_var) {
-        beta.obs_list <- get_bootstrap_draws()
-        sigma.obs_boot <- stats::cov(base::Reduce(base::rbind,
-                                                  beta.obs_list))
-        print(sigma.obs)
-        print(sigma.obs_boot)
-      }
     } else {
       beta.obs_list <- get_bootstrap_draws()
       sigma.obs <- stats::cov(base::Reduce(base::rbind,

--- a/README.Rmd
+++ b/README.Rmd
@@ -48,7 +48,7 @@ Baranov et al. (2020), $D$ is a treatment for depression and $Y$ is an index of
 outcomes for women's financial empowerment. We are interested in whether the
 effect of $D$ on $Y$ can be explained by a mediator, or set of mediators,
 $M$. We consider three choices for $M$: (a) the presence of a grandmother in the
-home, (b)relationship quality with the woman's husband, and (c) the combination
+home, (b) relationship quality with the woman's husband, and (c) the combination
 of these two mechanisms.
 
 ## Randomly-assigned setting 
@@ -93,7 +93,7 @@ description.
 We first provide graphical evidence using a partial density plot using the
 function `partial_density_plot()`. When $M$ is binary, such (partial) density
 plots are often helpful to understand where the violations of the *sharp null*
-are coming from. The following snippet reproduces Figure 3 of the main paper.
+are coming from. The following snippet reproduces Figure 3 of the paper.
 
 ```{r}
 nt_plot <-
@@ -187,8 +187,7 @@ The test above suggests that the treatment effect does not operate entirely thro
 affected by the treatment despite having the same value of $M$ under both
 treatments. This gives a sense of the strength of mechanisms other than $M$:
 it tells us what fraction of the never-takers have a direct effect of the
-treatment. The definition of the lower bounds can be found in Section 3.1 of the
-paper. The function `lb_frac_affected` computes (a point estimate of) this lower
+treatment. The function `lb_frac_affected` computes a point estimate of this lower
 bound. The argument `at_group = 0` corresponds to computing this lower bound for the never-takers, who are referred to as "0-always takers" in the more general notation in the paper.
 
 ```{r, cache = TRUE}
@@ -284,7 +283,7 @@ We note that while the method works with multi-valued discrete mediators (such a
 
 ### Combination of both mechanisms
 
-Finally, we test the null hypothesis that the treatment effect is explained by
+Next, we test the null hypothesis that the treatment effect is explained by
 the combination of the two mechanisms. This is done by passing a vector of variables names for the `m` argument. 
 ```{r, cache = TRUE}
 test_result_both <- test_sharp_null(df = mother_data,
@@ -318,54 +317,8 @@ We estimate a lower bound of `r round(100 * lb_frac_both)` percent, although thi
 to be statistically significant given the test result above.
 
 ## Non-experimental setting
-The examples above focus on data from a randomized controlled trial, where treatment $D$ is randomly assigned (at least within strata or clusters). However, TestMechs can also be applied in observational or other non-experimental settings, as long as we have a way to adjust for the non-random assignment of $D$. The package provides the reg_formula argument in all core functions to handle such cases via regression adjustment. If the treatment $D$ is as good as random conditional on some observed covariates (selection on observables), you can include those covariates in a formula. The functions will then adjust the estimated partial probabilities using OLS regression (essentially controlling for those covariates when computing the distributions). For example, if in the Baranov et al. study the treatment assignment had depended on age_baseline, edu_mo_baseline, and wealth_baseline, we could adjust for it:
+The examples above focus on data from a randomized controlled trial, where treatment $D$ is randomly assigned. TestMech assumes by default that we have an RCT, and treatment effects are estimated by comparing means for the treated and control group. However, TestMechs can also be applied in settings where we have conditional randomization given covariates or an instrumental variable for the treatment. Specifically, the core functions of the package allow for the `reg_formula` argument, which allows the researcher to provide a regression formula (or IV formula) to estimate treatment effects after adjusting linearly for observable characteristics. The `reg_formula` argument is passed to the `fixest` package to estimate treatment effects, and thus accommodates `fixest` functionality, including IV and high-dimensional fixed effects. While adjusting for covariates is not necessary in our running example, which is an RCT, we can still adjust for covariates to increase precision. Below we show how this is done using the baseline covariates `age_baseline`, `edu_mo_baseline`, and `wealth_baseline`. For brevity, we focus on testing the sharp null using covariates using the function `test_sharp_null()`, although the `reg_formula` result can analogously be passed to the functions `partial_density_plot()` and `lb_frac_affected()`. 
 
-### Graphical Evidence
-The partial_density_plot provides a visual check of the sharp null hypothesis for the grandmother mechanism, now adjusted for baseline covariates.
-```{r}
-nt_plot_ols <-
-  partial_density_plot(df = mother_data,
-                       d = "treat",
-                       m = "grandmother",
-                       y = "motherfinancial",
-                       num_Ybins = 5,
-                       plot_nts = T,
-                       reg_formula = "~ treat + age_baseline + edu_mo_baseline + wealth_baseline ",
-                       density_1_label = "Adj. Prob (P(Y,M=0|D=1))",
-                       density_0_label = "Adj. Prob (P(Y,M=0|D=0))") +
-  ylab("Adjusted Probability") +
-  xlab("Event: No Grandmother Present (M=0) and Y in Stated Range")
-
-nt_plot_ols +
-  theme(legend.position = "bottom",
-        legend.title = element_blank())
-```
-Here, we create an instrumental variable iv for the treatment variable treat. The partial_density_plot then uses this instrument to provide a more robust visual check if treat is endogenous.
-```{r}
-# Create instrument variable
-set.seed(123)
-mother_data$iv <- mother_data$treat + rnorm(nrow(mother_data), mean = 0, sd = 0.05)
-
-nt_plot_iv <-
-  partial_density_plot(df = mother_data,
-                       d = "treat",
-                       m = "grandmother",
-                       y = "motherfinancial",
-                       num_Ybins = 5,
-                       plot_nts = T,
-                       reg_formula = "~ age_baseline + edu_mo_baseline + wealth_baseline + (treat = iv)",
-                       density_1_label = "Adj. Prob (P(Y,M=0|D=1))",
-                       density_0_label = "Adj. Prob (P(Y,M=0|D=0))") +
-  ylab("Adjusted Probability") +
-  xlab("Event: No Grandmother Present (M=0) and Y in Stated Range")
-
-nt_plot_iv +
-  theme(legend.position = "bottom",
-        legend.title = element_blank())
-
-```
-### Testing the sharp null of full mediation
-In this example, reg_formula = "~ treat + age_baseline + edu_mo_baseline + wealth_baseline" tells the function to regression-adjust the calculations by first partialing out the effect of the age_baseline, edu_mo_baseline, wealth_baseline covariates (using OLS) from the treatment and outcome relationships. This would account for differences in covariates between treated and control groups, approximating a condition of conditional independence.
 ```{r}
 test_result_gm_ols <- test_sharp_null(df = mother_data,
                                        d = "treat",
@@ -377,145 +330,24 @@ test_result_gm_ols <- test_sharp_null(df = mother_data,
                                        cluster = "uc")
 test_result_gm_ols$pval
 ```
-Here we repeat the test for full mediation by grandmother, but now using an instrumental variable iv for treat. This IV approach is useful if treat may be endogenous; the instrument (assumed to be random) provides exogenous variation in treat.
+
+
+The key new argument is `reg_formula = "~ treat + age_baseline + edu_mo_baseline + wealth_baseline"`. This says that we should estimate the effect of the treatment (`treat`) on $Y$ and $M$ (or functions thereof) by running a regression with the treatment variable and baseline controls on the right-hand side. 
+
+We can also use `reg_formula` to estimate treatment effects using instrumental variables. To illustrate how this works, we create an instrumental variable `iv` equal to the true treatment variable plus noise. We now modify the `reg_formula` argument to use `iv` as an instrument for `treat`.
 ```{r}
+set.seed(0)
+mother_data$iv <- mother_data$treat + rnorm(n = length(mother_data$treat), sd = 0.1) #iv = treat + noise
+
 test_result_gm_iv <- test_sharp_null(df = mother_data,
                                        d = "treat",
                                        m = "grandmother",
                                        y = "motherfinancial",
-                                       reg_formula = "~ age_baseline + edu_mo_baseline + wealth_baseline + (treat = iv)",
+                                       reg_formula = "~ age_baseline + edu_mo_baseline + wealth_baseline + (treat = iv)", #iv spec
                                        method = "CS",
                                        num_Ybins = 5,
                                        cluster = "uc")
 
 test_result_gm_iv$pval
 ```
-Even after accounting for covariates (OLS) or using an exogenous shock to treatment (IV), we still find statistically significant violations of the sharp-null. This strengthens the case that some part of the treatment effect bypasses the grandmother mechanism.
 
-### Calculating the lower bound on fraction of always-takers affected by outcome
-```{r}
-lb_nts_gm_ols <- lb_frac_affected(df = mother_data,
-                                 d = "treat",
-                                 m = "grandmother",
-                                 y = "motherfinancial",
-                                 num_Ybins = 5,
-                                 reg_formula = "~ treat + age_baseline + edu_mo_baseline + wealth_baseline",
-                                 at_group = 0)
-lb_nts_gm_ols
-```
-After controlling for baseline age, maternal education, and household wealth, we still find that at least $18 \%$ of never-takers are affected by the treatment.
-```{r}
-lb_nts_gm_iv <- lb_frac_affected(df = mother_data,
-                                 d = "treat",
-                                 m = "grandmother",
-                                 y = "motherfinancial",
-                                 num_Ybins = 5,
-                                 reg_formula = "~ age_baseline + edu_mo_baseline + wealth_baseline + (treat = iv)",
-                                 at_group = 0)
-lb_nts_gm_iv
-```
-The bound is approximately $17.7\%$ when we instrument for treatment, implying that the conclusion is robust to potential endogeneity of treat.
-
-### Results for an alternative mechanism (relationship quality with husband)
-```{r}
-test_result_rh_ols <- test_sharp_null(df = mother_data,
-                                       d = "treat",
-                                       m = "relationship_husb",
-                                       y = "motherfinancial",
-                                       reg_formula = "~ treat + age_baseline + edu_mo_baseline + wealth_baseline",   
-                                       method = "CS",
-                                       num_Ybins = 5,
-                                       cluster = "uc")
-test_result_rh_ols$pval
-```
-After conditioning on baseline age, education, and wealth, the Cox–Shi test still rejects the sharp-null that all of the treatment effect runs through relationship quality with the husband. Hence, even after regression adjustment, this mediator by itself cannot fully account for the programme’s impact on mothers’ financial empowerment.
-```{r}
-test_result_rh_iv <- test_sharp_null(df = mother_data,
-                                      d = "treat",
-                                      m = "relationship_husb",
-                                      y = "motherfinancial",
-                                      reg_formula = "~ age_baseline + edu_mo_baseline + wealth_baseline + (treat = iv)",
-                                      method = "CS",
-                                      num_Ybins = 5,
-                                      cluster = "uc")
-
-test_result_rh_iv$pval
-```
-Using the randomly-perturbed instrument (iv) to address potential endogeneity of the treatment slightly raises the p-value, but it remains below $5 \%$. The inference is therefore robust: relationship quality alone does not appear to mediate the entire effect.
-```{r}
-lb_nts_rh_ols <- lb_frac_affected(df = mother_data,
-                                 d = "treat",
-                                 m = "relationship_husb",
-                                 y = "motherfinancial",
-                                 num_Ybins = 5,
-                                 reg_formula = "~ treat + age_baseline + edu_mo_baseline + wealth_baseline",
-                                 at_group = NULL,
-                                 allow_min_defiers = TRUE)
-lb_nts_rh_ols
-```
-```{r}
-lb_nts_rh_iv <- lb_frac_affected(df = mother_data,
-                                 d = "treat",
-                                 m = "relationship_husb",
-                                 y = "motherfinancial",
-                                 num_Ybins = 5,
-                                 reg_formula = "~ age_baseline + edu_mo_baseline + wealth_baseline + (treat = iv)",
-                                 at_group = NULL,
-                                 allow_min_defiers = TRUE)
-lb_nts_rh_iv
-```
-Both specifications trigger the “minimum-defiers” warning. The warning simply states that a very small share of “defiers” (≈ 1.5 %) is mathematically required to reconcile the empirical joint distribution of $(Y,M,D)$ with the monotonicity assumption. After allowing for this minimal share, the lower-bound calculation proceeds as usual.
-
-### Combination of both mechanisms
-
-```{r}
-test_result_both_ols <- test_sharp_null(df = mother_data,
-                                       d = "treat",
-                                       m = c("relationship_husb",
-                                          "grandmother"),
-                                       y = "motherfinancial",
-                                       reg_formula = "~ treat + age_baseline + edu_mo_baseline + wealth_baseline",   
-                                       method = "CS",
-                                       num_Ybins = 5,
-                                       cluster = "uc")
-test_result_both_ols$pval
-```
-
-```{r}
-test_result_both_iv <- test_sharp_null(df = mother_data,
-                                      d = "treat",
-                                      m = c("relationship_husb",
-                                          "grandmother"),
-                                      y = "motherfinancial",
-                                      reg_formula = "~ age_baseline + edu_mo_baseline + wealth_baseline + (treat = iv)",
-                                      method = "CS",
-                                      num_Ybins = 5,
-                                      cluster = "uc")
-
-test_result_both_iv$pval
-```
-Because both p-values are well above conventional significance thresholds, we fail to reject the sharp-null hypothesis that the joint action of the two mediators fully transmits the treatment effect.
-```{r}
-lb_nts_both_ols <- lb_frac_affected(df = mother_data,
-                                 d = "treat",
-                                 m = c("relationship_husb",
-                                          "grandmother"),
-                                 y = "motherfinancial",
-                                 num_Ybins = 5,
-                                 reg_formula = "~ treat + age_baseline + edu_mo_baseline + wealth_baseline",
-                                 allow_min_defiers = TRUE)
-lb_nts_both_ols
-```
-Once we allow both mediators to operate jointly, approximately $6.5\%$ of individuals who would keep the same $M$ under treatment vs. control (always-/never-takers) are required to experience a residual direct effect on the outcome.
-```{r}
-lb_nts_both_iv <- lb_frac_affected(df = mother_data,
-                                 d = "treat",
-                                 m = c("relationship_husb",
-                                          "grandmother"),
-                                 y = "motherfinancial",
-                                 num_Ybins = 5,
-                                 reg_formula = "~ age_baseline + edu_mo_baseline + wealth_baseline + (treat = iv)",
-                                 allow_min_defiers = TRUE)
-lb_nts_both_iv
-```
-The IV-adjustment outcome is nearly identical to the OLS-adjustment outcome, confirming that potential endogeneity of treat does not materially change the conclusion. The routine checks whether the empirical data can satisfy the monotonicity assumption for the specified maximum share of defiers. Because of allow_min_defiers = TRUE, the function automatically relaxes the defier share to the smallest value compatible with the data ($\approx 1.5 \%$). 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@ by Soonwoo Kwon and Jonathan Roth. The package provides tests for the
 treatment operates through a particular conjectured mechanism (or set of
 mechanisms) M. It also provides lower bounds on the fraction of
 “always-takers” who are affected by the treatment despite having the
-same value of M regardless of treatment status. For now, the package
-assumes that the treatment is as good as randomly assigned (as in an
-RCT); we hope to add support for conditional random assignment in future
-iterations of the package. Note that the approach in the paper requires
-the mediator $M$ to be discrete.
+same value of M regardless of treatment status. All core functions in
+the package — test_sharp_null(), lb_frac_affected(), and
+partial_density_plot() — support conditional random assignment and
+accept a reg_formula argument. When you provide a formula, the package
+regression-adjusts the relevant partial probabilities using OLS or IV.
+Note that the approach in the paper requires the mediator $M$ to be
+discrete. If reg_formula is omitted, the functions assume that the
+treatment is as good as randomly assigned (as in an RCT).
 
 ## Installation
 
@@ -43,9 +46,11 @@ In Baranov et al. (2020), $D$ is a treatment for depression and $Y$ is
 an index of outcomes for women’s financial empowerment. We are
 interested in whether the effect of $D$ on $Y$ can be explained by a
 mediator, or set of mediators, $M$. We consider three choices for $M$:
-(a) the presence of a grandmother in the home, (b)relationship quality
+(a) the presence of a grandmother in the home, (b) relationship quality
 with the woman’s husband, and (c) the combination of these two
 mechanisms.
+
+## Randomly-assigned setting
 
 We start with loading the required packages and the data.
 
@@ -78,9 +83,11 @@ plot the partial densities to visually detect potential violations of
 the *sharp null*, 2) `test_sharp_null()` to conduct a statistical test
 for the *sharp null* and 3) `lb_frac_affected()` to compute the sharp
 lower bound for the fraction of always-takers (or never-takers) that are
-affected by treatment. While this example covers the basic usage of
-these functions, please refer to the documentation of each function
-(e.g., `?test_sharp_null`) for a more detailed description.
+affected by treatment. Each function can be adjusted for conditional
+random assignment by providing a reg_formula if needed (e.g., adding
+baseline covariates or instruments). While this example covers the basic
+usage of these functions, please refer to the documentation of each
+function (e.g., `?test_sharp_null`) for a more detailed description.
 
 ### Graphical Evidence
 
@@ -88,7 +95,7 @@ We first provide graphical evidence using a partial density plot using
 the function `partial_density_plot()`. When $M$ is binary, such
 (partial) density plots are often helpful to understand where the
 violations of the *sharp null* are coming from. The following snippet
-reproduces Figure 3 of the main paper.
+reproduces Figure 3 of the paper.
 
 ``` r
 nt_plot <-
@@ -212,12 +219,11 @@ mechanisms?To give a sense, we now compute lower bounds on the fraction
 of never-takers whose outcome is affected by the treatment despite
 having the same value of $M$ under both treatments. This gives a sense
 of the strength of mechanisms other than $M$: it tells us what fraction
-of the never-takers have a direct effect of the treatment. The
-definition of the lower bounds can be found in Section 3.1 of the paper.
-The function `lb_frac_affected` computes (a point estimate of) this
-lower bound. The argument `at_group = 0` corresponds to computing this
-lower bound for the never-takers, who are referred to as “0-always
-takers” in the more general notation in the paper.
+of the never-takers have a direct effect of the treatment. The function
+`lb_frac_affected` computes a point estimate of this lower bound. The
+argument `at_group = 0` corresponds to computing this lower bound for
+the never-takers, who are referred to as “0-always takers” in the more
+general notation in the paper.
 
 ``` r
 lb_nts <- lb_frac_affected(df = mother_data,
@@ -342,9 +348,9 @@ discretization of $M$.
 
 ### Combination of both mechanisms
 
-Finally, we test the null hypothesis that the treatment effect is
-explained by the combination of the two mechanisms. This is done by
-passing a vector of variables names for the `m` argument.
+Next, we test the null hypothesis that the treatment effect is explained
+by the combination of the two mechanisms. This is done by passing a
+vector of variables names for the `m` argument.
 
 ``` r
 test_result_both <- test_sharp_null(df = mother_data,
@@ -382,3 +388,71 @@ lb_frac_both
 
 We estimate a lower bound of 7 percent, although this does not appear to
 be statistically significant given the test result above.
+
+## Non-experimental setting
+
+The examples above focus on data from a randomized controlled trial,
+where treatment $D$ is randomly assigned. TestMech assumes by default
+that we have an RCT, and treatment effects are estimated by comparing
+means for the treated and control group. However, TestMechs can also be
+applied in settings where we have conditional randomization given
+covariates or an instrumental variable for the treatment. Specifically,
+the core functions of the package allow for the `reg_formula` argument,
+which allows the researcher to provide a regression formula (or IV
+formula) to estimate treatment effects after adjusting linearly for
+observable characteristics. The `reg_formula` argument is passed to the
+`fixest` package to estimate treatment effects, and thus accommodates
+`fixest` functionality, including IV and high-dimensional fixed effects.
+While adjusting for covariates is not necessary in our running example,
+which is an RCT, we can still adjust for covariates to increase
+precision. Below we show how this is done using the baseline covariates
+`age_baseline`, `edu_mo_baseline`, and `wealth_baseline`. For brevity,
+we focus on testing the sharp null using covariates using the function
+`test_sharp_null()`, although the `reg_formula` result can analogously
+be passed to the functions `partial_density_plot()` and
+`lb_frac_affected()`.
+
+``` r
+test_result_gm_ols <- test_sharp_null(df = mother_data,
+                                       d = "treat",
+                                       m = "grandmother",
+                                       y = "motherfinancial",
+                                       reg_formula = "~ treat + age_baseline + edu_mo_baseline + wealth_baseline",   
+                                       method = "CS",
+                                       num_Ybins = 5,
+                                       cluster = "uc")
+#> Loading required package: lpinfer
+test_result_gm_ols$pval
+#>            [,1]
+#> [1,] 0.03105106
+```
+
+The key new argument is
+`reg_formula = "~ treat + age_baseline + edu_mo_baseline + wealth_baseline"`.
+This says that we should estimate the effect of the treatment (`treat`)
+on $Y$ and $M$ (or functions thereof) by running a regression with the
+treatment variable and baseline controls on the right-hand side.
+
+We can also use `reg_formula` to estimate treatment effects using
+instrumental variables. To illustrate how this works, we create an
+instrumental variable `iv` equal to the true treatment variable plus
+noise. We now modify the `reg_formula` argument to use `iv` as an
+instrument for `treat`.
+
+``` r
+set.seed(0)
+mother_data$iv <- mother_data$treat + rnorm(n = length(mother_data$treat), sd = 0.1) #iv = treat + noise
+
+test_result_gm_iv <- test_sharp_null(df = mother_data,
+                                       d = "treat",
+                                       m = "grandmother",
+                                       y = "motherfinancial",
+                                       reg_formula = "~ age_baseline + edu_mo_baseline + wealth_baseline + (treat = iv)", #iv spec
+                                       method = "CS",
+                                       num_Ybins = 5,
+                                       cluster = "uc")
+
+test_result_gm_iv$pval
+#>            [,1]
+#> [1,] 0.03082124
+```

--- a/man/test_sharp_null_binary_m.Rd
+++ b/man/test_sharp_null_binary_m.Rd
@@ -22,8 +22,7 @@ test_sharp_null_binary_m(
   fix_n1 = T,
   lambda = "dd",
   analytic_variance = FALSE,
-  refinement = FALSE,
-  print_both_var = FALSE
+  refinement = FALSE
 )
 }
 \arguments{
@@ -54,8 +53,7 @@ ordering is used.}
 @param fix_n1 Whether the number of treated units (or clusters) should be fixed in the bootstrap
 @param lambda (For FSST only) A string variable, either dd or ndd, standing for data-driven or non-data driven respectively.
 @param analytic_variance (For CS or ARP only) A flag indicating whether to use analytic variance.
-@param refinement (For CS only, optional) If TRUE, use the refined Cox & Shi test (rCC rather than CC). Default is FALSE.
-@param print_both_var (For CS only, Optional) If TRUE, print sigma from both actual and bootstrapped data.}
+@param refinement (For CS only, optional) If TRUE, use the refined Cox & Shi test (rCC rather than CC). Default is FALSE.}
 }
 \description{
 This function tests the sharp null of Y(1,m) = Y(0,m). The

--- a/tests/testthat/test-regression-equivalence.R
+++ b/tests/testthat/test-regression-equivalence.R
@@ -1,0 +1,294 @@
+skip_if_not_installed("fixest")
+skip_if_not_installed("osqp")
+skip_if_not_installed("Rglpk")
+
+setup_baranov_data <- function() {
+  data("baranov_data", package = "TestMechs")
+  mother_data <- mother_data |> dplyr::filter(THP_sample == 1)
+  mother_data_plus_fake <- dplyr::bind_rows(
+    mother_data |> dplyr::mutate(fake = 0),
+    mother_data |> dplyr::mutate(treat = 0, fake = 1)
+  )
+
+  list(
+    mother_data = mother_data,
+    mother_data_plus_fake = mother_data_plus_fake
+  )
+}
+
+expect_equivalent_results <- function(ref, ...) {
+  lapply(list(...), function(candidate) {
+    testthat::expect_equal(candidate, ref, tolerance = 1e-8)
+  })
+}
+
+test_that("test_sharp_null regression adjustments match baseline (binary M)", {
+  datasets <- setup_baranov_data()
+
+  base_res <- test_sharp_null(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "grandmother",
+    y = "motherfinancial",
+    method = "CS",
+    num_Ybins = 5,
+    cluster = "uc"
+  )
+
+  trivial_res <- test_sharp_null(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "grandmother",
+    y = "motherfinancial",
+    method = "CS",
+    num_Ybins = 5,
+    cluster = "uc",
+    reg_formula = "~ treat"
+  )
+
+  augmented_res <- test_sharp_null(
+    df = datasets$mother_data_plus_fake,
+    d = "treat",
+    m = "grandmother",
+    y = "motherfinancial",
+    method = "CS",
+    num_Ybins = 5,
+    cluster = "uc",
+    reg_formula = "~ treat | fake",
+    analytic_variance = TRUE
+  )
+
+  expect_equivalent_results(base_res, trivial_res, augmented_res)
+})
+
+test_that("test_sharp_null regression adjustments match baseline (nonbinary M)", {
+  datasets <- setup_baranov_data()
+
+  base_res <- test_sharp_null(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "relationship_husb",
+    y = "motherfinancial",
+    method = "CS",
+    num_Ybins = 5,
+    cluster = "uc"
+  )
+
+  trivial_res <- test_sharp_null(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "relationship_husb",
+    y = "motherfinancial",
+    method = "CS",
+    num_Ybins = 5,
+    cluster = "uc",
+    reg_formula = "~ treat"
+  )
+
+  expect_equivalent_results(base_res, trivial_res)
+})
+
+test_that("fixest control and IV specifications align for nonbinary M", {
+  datasets <- setup_baranov_data()
+
+  controls_res <- test_sharp_null(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "relationship_husb",
+    y = "motherfinancial",
+    method = "CS",
+    num_Ybins = 5,
+    cluster = "uc",
+    reg_formula = "~ treat + factor(interviewer)"
+  )
+
+  fe_res <- test_sharp_null(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "relationship_husb",
+    y = "motherfinancial",
+    method = "CS",
+    num_Ybins = 5,
+    cluster = "uc",
+    reg_formula = "~ treat | interviewer"
+  )
+
+  iv_res <- test_sharp_null(
+    df = datasets$mother_data |> dplyr::mutate(treativ = treat),
+    d = "treat",
+    m = "relationship_husb",
+    y = "motherfinancial",
+    method = "CS",
+    num_Ybins = 5,
+    cluster = "uc",
+    reg_formula = "~ (treat = treativ) | interviewer"
+  )
+
+  expect_equivalent_results(controls_res, fe_res, iv_res)
+})
+
+test_that("fixest control and IV specifications align for binary M", {
+  datasets <- setup_baranov_data()
+
+  controls_res <- test_sharp_null(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "grandmother",
+    y = "motherfinancial",
+    method = "CS",
+    num_Ybins = 5,
+    cluster = "uc",
+    reg_formula = "~ treat + factor(interviewer)"
+  )
+
+  fe_res <- test_sharp_null(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "grandmother",
+    y = "motherfinancial",
+    method = "CS",
+    num_Ybins = 5,
+    cluster = "uc",
+    reg_formula = "~ treat | interviewer"
+  )
+
+  iv_res <- test_sharp_null(
+    df = datasets$mother_data |> dplyr::mutate(treativ = treat),
+    d = "treat",
+    m = "grandmother",
+    y = "motherfinancial",
+    method = "CS",
+    num_Ybins = 5,
+    cluster = "uc",
+    reg_formula = "~ (treat = treativ) | interviewer"
+  )
+
+  expect_equivalent_results(controls_res, fe_res, iv_res)
+})
+
+test_that("lb_frac_affected respects regression choices", {
+  datasets <- setup_baranov_data()
+
+  baseline <- lb_frac_affected(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "relationship_husb",
+    y = "motherfinancial",
+    num_Ybins = 5,
+    allow_min_defiers = TRUE
+  )
+
+  trivial <- lb_frac_affected(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "relationship_husb",
+    y = "motherfinancial",
+    num_Ybins = 5,
+    reg_formula = "~ treat",
+    allow_min_defiers = TRUE
+  )
+
+  controls <- lb_frac_affected(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "relationship_husb",
+    y = "motherfinancial",
+    num_Ybins = 5,
+    reg_formula = "~ treat + factor(interviewer)",
+    allow_min_defiers = TRUE
+  )
+
+  fe <- lb_frac_affected(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "relationship_husb",
+    y = "motherfinancial",
+    num_Ybins = 5,
+    reg_formula = "~ treat | interviewer",
+    allow_min_defiers = TRUE
+  )
+
+  iv <- lb_frac_affected(
+    df = datasets$mother_data |> dplyr::mutate(treativ = treat),
+    d = "treat",
+    m = "relationship_husb",
+    y = "motherfinancial",
+    num_Ybins = 5,
+    reg_formula = "~ (treat=treativ) | interviewer",
+    allow_min_defiers = TRUE
+  )
+
+  expect_equivalent_results(baseline, trivial, controls, fe, iv)
+})
+
+test_that("lb_frac_affected matches across mediator vector regressions", {
+  datasets <- setup_baranov_data()
+
+  baseline <- lb_frac_affected(
+    df = datasets$mother_data,
+    d = "treat",
+    m = c("relationship_husb", "grandmother"),
+    y = "motherfinancial",
+    num_Ybins = 5,
+    allow_min_defiers = TRUE
+  )
+
+  trivial <- lb_frac_affected(
+    df = datasets$mother_data,
+    d = "treat",
+    m = c("relationship_husb", "grandmother"),
+    y = "motherfinancial",
+    num_Ybins = 5,
+    reg_formula = "~ treat",
+    allow_min_defiers = TRUE
+  )
+
+  expect_equivalent_results(baseline, trivial)
+})
+
+test_that("partial_density_plot agrees across regression specifications", {
+  datasets <- setup_baranov_data()
+
+  plot_base <- partial_density_plot(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "grandmother",
+    y = "motherfinancial",
+    num_Ybins = 5
+  )
+
+  plot_trivial <- partial_density_plot(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "grandmother",
+    y = "motherfinancial",
+    num_Ybins = 5,
+    reg_formula = "~ treat"
+  )
+
+  plot_controls <- partial_density_plot(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "grandmother",
+    y = "motherfinancial",
+    num_Ybins = 5,
+    reg_formula = "~ treat + factor(interviewer)"
+  )
+
+  plot_fe <- partial_density_plot(
+    df = datasets$mother_data,
+    d = "treat",
+    m = "grandmother",
+    y = "motherfinancial",
+    num_Ybins = 5,
+    reg_formula = "~ treat | interviewer"
+  )
+
+  plots_data <- list(plot_base, plot_trivial, plot_controls, plot_fe) |>
+    lapply(ggplot2::ggplot_build) |>
+    lapply("[[", "data")
+
+  lapply(plots_data[-1], function(layer_data) {
+    expect_equal(layer_data, plots_data[[1]])
+  })
+})


### PR DESCRIPTION
## Summary
- this PR makes multiple updates to the non-experimental functionality
- we fixed bugs that were ignoring general fixest formulas (with FEs) 
- simplified the regression code to rely on common helper utilities
- the Lee bounds computation (compute_bounds_ats_new) still needs work to be functional with continuous Y
------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e509b9b8083308d904e44c8c3d3b8)