### PR TITLE
Remove export tags from test_sharp_null helpers

### DIFF
--- a/R/test_sharp_null_arp.R
+++ b/R/test_sharp_null_arp.R
@@ -18,7 +18,6 @@
 #'   are "diag", "avar", "identity." Defaults is "diag" as in FSST.
 #' @param num_Ybins (Optional) If specified, Y is discretized into the given number of bins (if num_Ybins is larger than the number of unique values of Y, no changes are made)
 #' @param alpha Significance level. Default is 0.05
-#' @export
 test_sharp_null_arp <- function(df,
                             d,
                             m,

--- a/R/test_sharp_null_arp_binary_m.R
+++ b/R/test_sharp_null_arp_binary_m.R
@@ -17,10 +17,9 @@
 #' @param weight.matrix Weight matrix used to implement FSST. Possible options
 #'   are "diag", "avar", "identity." Defaults is "diag" as in FSST.
 #' @param num_Ybins (Optional) If specified, Y is discretized into the given number of bins (if num_Ybins is larger than the number of unique values of Y, no changes are made)
-#' @export
 test_sharp_null_arp_binary_m <- function(df,
-                                d,
-                                m,
+                                        d,
+                                        m,
                                 y,
                                 ordering = NULL,
                                 B = 500,

--- a/R/test_sharp_null_binary_m.R
+++ b/R/test_sharp_null_binary_m.R
@@ -24,8 +24,6 @@
 #'  @param lambda (For FSST only) A string variable, either dd or ndd, standing for data-driven or non-data driven respectively.
 #'  @param analytic_variance (For CS or ARP only) A flag indicating whether to use analytic variance.
 #'  @param refinement (For CS only, optional) If TRUE, use the refined Cox & Shi test (rCC rather than CC). Default is FALSE.
-#' @export
-
 test_sharp_null_binary_m <- function(df,
                                      d,
                                      m,

--- a/R/test_sharp_null_coxandshi_binary_m.R
+++ b/R/test_sharp_null_coxandshi_binary_m.R
@@ -18,10 +18,9 @@
 #'   are "diag", "avar", "identity." Defaults is "diag" as in FSST.
 #'  @param num_Ybins (Optional) If specified, Y is discretized into the given number of bins (if num_Ybins is larger than the number of unique values of Y, no changes are made)
 #'  @param refinement (Optional) If TRUE, use the refined Cox & Shi test (rCC rather than CC). Default is FALSE.
-#' @export
 test_sharp_null_coxandshi_binary_m <- function(df,
-                                         d,
-                                         m,
+                                              d,
+                                              m,
                                          y,
                                          ordering = NULL,
                                          B = 500,

--- a/R/test_sharp_null_cr.R
+++ b/R/test_sharp_null_cr.R
@@ -17,7 +17,6 @@
 #'   objective/constraints
 #' @param alpha Significance level. Default value is .05
 #' @param num_Ybins (Optional) If specified, Y is discretized into the given number of bins (if num_Ybins is larger than the number of unique values of Y, no changes are made)
-#' @export
 test_sharp_null_cr <- function(df, d, m, y, ordering = NULL, B = 500,
                                eps_bar = 1e-03, alpha = .05, num_Ybins = NULL){
 

--- a/R/test_sharp_null_fsst.R
+++ b/R/test_sharp_null_fsst.R
@@ -17,7 +17,6 @@
 #'   are "diag", "avar", "identity." Defaults is "diag" as in FSST.
 #' @param alpha Significance level. Default value is .05.
 #' @param num_Ybins (Optional) If specified, Y is discretized into the given number of bins (if num_Ybins is larger than the number of unique values of Y, no changes are made)
-#' @export
 test_sharp_null_fsst <- function(df, d, m, y, ordering = NULL, B = 500,
                                  weight.matrix = "diag", alpha = .05,
                                  num_Ybins = NULL, lambda = NA){
@@ -177,7 +176,6 @@ test_sharp_null_fsst <- function(df, d, m, y, ordering = NULL, B = 500,
 #' @param weight.matrix Weight matrix used to implement FSST. Possible options
 #'   are "diag", "avar", "identity." Defaults is "diag" as in FSST.
 #' @param alpha Significance level. Default value is .05.
-#' @export
 test_sharp_null_alt <- function(df,
                                 d,
                                 m,

--- a/R/test_sharp_null_fsst_binary_m.R
+++ b/R/test_sharp_null_fsst_binary_m.R
@@ -17,10 +17,9 @@
 #' @param weight.matrix Weight matrix used to implement FSST. Possible options
 #'   are "diag", "avar", "identity." Defaults is "diag" as in FSST.
 #' @param num_Ybins (Optional) If specified, Y is discretized into the given number of bins (if num_Ybins is larger than the number of unique values of Y, no changes are made)
-#' @export
 test_sharp_null_fsst_binary_m <- function(df,
-                                          d,
-                                          m,
+                                         d,
+                                         m,
                                           y,
                                           ordering = NULL,
                                           B = 500,

--- a/R/test_sharp_null_toru.R
+++ b/R/test_sharp_null_toru.R
@@ -9,7 +9,6 @@
 #' @param B Bootstrap size, default is 500
 #' @param alpha Significance level. Default value is .05
 #' @param num_Ybins (Optional) If specified, Y is discretized into the given number of bins (if num_Ybins is larger than the number of unique values of Y, no changes are made)
-#' @export
 test_sharp_null_toru <- function(df, d, m, y, B = 500, alpha = .05, num_Ybins = NULL, cluster = NULL) {
 
   df <- remove_missing_from_df(df = df,


### PR DESCRIPTION
## Summary
- remove roxygen @export tags from test_sharp_null helper functions so only the main test_sharp_null is exported after roxygen is rerun

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69208da6cb7c8330b12edc895eea788d)