### PR TITLE
Addressing warning messages when using test_sharp_null()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Imports:
     Rglpk,
     sandwich
 Remotes:
-    asheshrambachan/HonestDiD
+    asheshrambachan/HonestDiD,
+    conroylau/lpinfer
 RoxygenNote: 7.3.2
 Suggests: 
     gurobi,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Imports:
     magrittr,
     osqp,
     purrr,
+    tidyr,
     quadprog,
     reshape2,
     Rglpk,

--- a/R/partial_density_plot.R
+++ b/R/partial_density_plot.R
@@ -237,7 +237,7 @@ compute_partial_densities_and_shares <- function(df,
 
         yvalues <- sort(unique(yvec))
         mvalues <- unique(mvec)
-        my_values <- purrr::cross_df(list(m = mvalues, y = yvalues)) %>%
+        my_values <- tidyr::expand_grid(m = mvalues, y = yvalues) %>%
           dplyr::arrange(m, y) %>%
           dplyr::select(y, m)
         my_values$m <- as.numeric(as.character(my_values$m))

--- a/R/test_sharp_null.R
+++ b/R/test_sharp_null.R
@@ -204,7 +204,7 @@ devtools::install_github('conroylau/lpinfer')")
   #Note we need to do this here so that the yvalues remain constant across boostrap draws
   yvalues <- unique(yvec)
   mvalues <- unique(mvec)
-  my_values <- purrr::cross_df(list(m=mvalues,y=yvalues)) %>%
+  my_values <- tidyr::expand_grid(m=mvalues,y=yvalues) %>%
     dplyr::arrange(m,y) %>%
     dplyr::select(y,m)
 

--- a/R/test_sharp_null_arp.R
+++ b/R/test_sharp_null_arp.R
@@ -156,7 +156,7 @@ df[[y]] <- yvec
 
   yvalues <- unique(yvec)
   mvalues <- unique(mvec)
-  my_values <- purrr::cross_df(list(m=mvalues,y=yvalues)) %>%
+  my_values <- tidyr::expand_grid(m=mvalues,y=yvalues) %>%
                 dplyr::arrange(m,y) %>%
                 dplyr::select(y,m)
 

--- a/R/test_sharp_null_arp_binary_m.R
+++ b/R/test_sharp_null_arp_binary_m.R
@@ -55,7 +55,7 @@ test_sharp_null_arp_binary_m <- function(df,
 
   yvalues <- sort(unique(yvec))
   mvalues <- unique(mvec)
-  my_values <- purrr::cross_df(list(m=mvalues,y=yvalues)) %>%
+  my_values <- tidyr::expand_grid(m=mvalues,y=yvalues) %>%
     dplyr::arrange(m,y) %>%
     dplyr::select(y,m)
 

--- a/R/test_sharp_null_binary_m.R
+++ b/R/test_sharp_null_binary_m.R
@@ -78,7 +78,7 @@ test_sharp_null_binary_m <- function(df,
   
   yvalues <- sort(unique(yvec))
   mvalues <- unique(mvec)
-  my_values <- purrr::cross_df(list(m=mvalues,y=yvalues)) %>%
+  my_values <- tidyr::expand_grid(m=mvalues,y=yvalues) %>%
     dplyr::arrange(m,y) %>%
     dplyr::select(y,m)
   

--- a/R/test_sharp_null_coxandshi_binary_m.R
+++ b/R/test_sharp_null_coxandshi_binary_m.R
@@ -60,7 +60,7 @@ test_sharp_null_coxandshi_binary_m <- function(df,
 
   yvalues <- sort(unique(yvec))
   mvalues <- unique(mvec)
-  my_values <- purrr::cross_df(list(m=mvalues,y=yvalues)) %>%
+  my_values <- tidyr::expand_grid(m=mvalues,y=yvalues) %>%
     dplyr::arrange(m,y) %>%
     dplyr::select(y,m)
 

--- a/R/test_sharp_null_fsst_binary_m.R
+++ b/R/test_sharp_null_fsst_binary_m.R
@@ -57,7 +57,7 @@ test_sharp_null_fsst_binary_m <- function(df,
 
   yvalues <- sort(unique(yvec))
   mvalues <- unique(mvec)
-  my_values <- purrr::cross_df(list(m=mvalues,y=yvalues)) %>%
+  my_values <- tidyr::expand_grid(m=mvalues,y=yvalues) %>%
     dplyr::arrange(m,y) %>%
     dplyr::select(y,m)
 


### PR DESCRIPTION
Hi Jonathan,

Thank you sincerely for a wonderful paper and software package. My team and I are very much looking forward to using your work.

While testing the package, we encountered the following warning messages:

`
Warning messages:
1: In library(package, lib.loc = lib.loc, character.only = TRUE, logical.return = TRUE,  :
  there is no package called ‘lpinfer’
2: `cross_df()` was deprecated in purrr 1.0.0.
ℹ Please use `tidyr::expand_grid()` instead.
ℹ See <[https://github.com/tidyverse/purrr/issues/768](vscode-file://vscode-app/c:/Users/B199526/AppData/Local/Programs/Positron/resources/app/out/vs/code/electron-browser/workbench/workbench.html#)>.
ℹ The deprecated feature was likely used in the TestMechs package.
  Please report the issue to the authors.
This warning is displayed once every 8 hours.
Call `lifecycle::last_lifecycle_warnings()` to see where this warning was generated. 
3: `cross()` was deprecated in purrr 1.0.0.
ℹ Please use `tidyr::expand_grid()` instead.
ℹ See <[https://github.com/tidyverse/purrr/issues/768](vscode-file://vscode-app/c:/Users/B199526/AppData/Local/Programs/Positron/resources/app/out/vs/code/electron-browser/workbench/workbench.html#)>.
ℹ The deprecated feature was likely used in the purrr package.
  Please report the issue at <[https://github.com/tidyverse/purrr/issues](vscode-file://vscode-app/c:/Users/B199526/AppData/Local/Programs/Positron/resources/app/out/vs/code/electron-browser/workbench/workbench.html#)>.
`
These warnings caused some confusion among my colleagues, particularly those who primarily use Stata. To accommodate this, I have added lpinfer to Remotes in the DESCRIPTION file. In addition, I have updated purrr::cross_df() to tidyr::expand_grid() and added tidyr to Imports. 

All the best to you, and once again, thank you.


Best wishes, 
Mikkel 